### PR TITLE
remove binary compiled program from repository

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,2 +1,15 @@
-*.exe
 *.zip
+
+# Binaries for programs and plugins
+*.exe
+*.exe~
+*.dll
+*.so
+*.dylib
+main/main
+
+# Test binary, built with `go test -c`
+*.test
+
+# Output of the go coverage tool, specifically when used with LiteIDE
+*.out


### PR DESCRIPTION
Just cleaning up the repository.  Unless there is a requirement for the binary to be in the repo, I think it's best to remove it.